### PR TITLE
Fixing "Invalid JDK version in profile 'java8-disable-doclint':

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.2.1.RELEASE</version>
+    <version>1.3.0.RELEASE</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 


### PR DESCRIPTION
Fixing "Unbounded range: [1.8, for project org.atteo:parent" error message.

The issue in org.atteo:parent has already been resolved. Please refer to: atteo/parent#1  It requires updating Atteo Parent version.

Atteo Parent is used by Spring Boot Starter Parent. I have tested various release between 1.2.1 and 1.3.0 (http://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-parent). Only version 1.3.0 resolved this issue.        
